### PR TITLE
docs: add commit signing summary

### DIFF
--- a/labs/submission3.md
+++ b/labs/submission3.md
@@ -1,0 +1,10 @@
+# Benefits of signing commits
+
+Signing commits using SSH or GPG provides:
+
+-  Author authentication - confirms that the commit was made by the real owner of the key.
+- Data integrity - ensures that the commit has not been modified after creation.
+- Anti-forgery protection - eliminates the possibility of falsifying the project history.
+- Verified label on GitHub - increases trust in the code and its origin.
+
+GitHub keeps the signature verification forever, even if the key is later revoked or expires. SSH signature is easier to set up and can use an existing key.


### PR DESCRIPTION
## Goal

Configure commit signing via SSH and pre-commit hook to find secrets.

## Changes

 Generated SSH key ed25519, added to GitHub.  
 Configured Git for signing commits.  
 Created submission3.md file with description of benefits of signatures.  
 Added pre-commit hook with TruffleHog and Gitleaks.

## Testing

 A test secret has been added — the commit is blocked.  
 After deletion — the commit passed.  
 Hook works correctly when there are no staged files.

## Artifacts & Screenshots

 Signed commit: docs: add commit signing summary  
 Screenshots: lock with secret, successful commit  
 submission3.md contains a brief description of the benefits of signatures.

## Checklist
- [x] Clear title
- [x] Docs updated if needed
- [x] No secrets/large temp files
- [x] Task 1 done
- [x] Task 2 done
- [x] Task 3 done
- [x] Screenshots attached (if applicable)